### PR TITLE
SPM-64 Create Single Course APIs

### DIFF
--- a/restful_api/myapi/api/resources/__init__.py
+++ b/restful_api/myapi/api/resources/__init__.py
@@ -1,6 +1,6 @@
 from myapi.api.resources.user import UserResource, UserList
-from myapi.api.resources.course import CourseList
+from myapi.api.resources.course import CourseList, CourseResource
 from myapi.api.resources.employee import EmployeeList, EmployeeResource
 
-__all__ = ["UserResource", "UserList", "EmployeeList", "EmployeeResource", "CourseList"]
+__all__ = ["UserResource", "UserList", "EmployeeList", "EmployeeResource", "CourseList", "CourseResource"]
 

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -1,6 +1,6 @@
 from flask import request
 from flask_jwt_extended import jwt_required
-from flask_restful import Resource
+from flask_restful import Resource, reqparse
 from myapi.api.schemas import CourseSchema
 from myapi.commons.pagination import paginate
 from myapi.extensions import db
@@ -18,6 +18,26 @@ class CourseResource(Resource):
           content:
             application/json:
               schema: CourseSchema
+
+    post:
+      tags:
+        - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              CourseSchema
+      responses:
+        201:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  msg:
+                    type: string
+                    example: course created
+                  course: CourseSchema
     """
     # method_decorators = [jwt_required()]
 
@@ -31,6 +51,16 @@ class CourseResource(Resource):
         schema = CourseSchema()
         courses = schema.dump(query)
         return courses
+
+    # Removing 'course_id' will raise error when parsing
+    def post(self, course_id):
+        schema = CourseSchema()
+        course = schema.load(request.json)
+
+        db.session.add(course)
+        db.session.commit()
+
+        return {"msg": "course created", "course": schema.dump(course)}, 201
 
 
 # -------

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -45,7 +45,7 @@ class CourseResource(Resource):
                     example: course created
                   course: CourseSchema
     """
-    # method_decorators = [jwt_required()]
+    method_decorators = [jwt_required()]
 
     def get(self, course_id):
         try:

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -4,8 +4,33 @@ from flask_restful import Resource
 from myapi.api.schemas import CourseSchema
 from myapi.commons.pagination import paginate
 from myapi.extensions import db
-from myapi.models import Course
+from myapi.models import Course, Prereq
 
+class CourseResource(Resource):
+    """Get one course
+
+    ---
+    get:
+      tags:
+        - api
+      responses:
+        200:
+          content:
+            application/json:
+              schema: CourseSchema
+    """
+    # method_decorators = [jwt_required()]
+
+    def get(self, course_id):
+        query = (
+          Course.query
+          .join(Prereq)
+          .filter(Course.course_id == course_id)
+          .one()
+        )
+        schema = CourseSchema()
+        courses = schema.dump(query)
+        return courses
 
 
 # -------

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -17,7 +17,13 @@ class CourseResource(Resource):
         200:
           content:
             application/json:
-              schema: CourseSchema
+              schema:
+                type: object
+                properties:
+                  msg:
+                    type: string
+                    example: course retrieved
+                  course: CourseSchema
 
     post:
       tags:
@@ -57,7 +63,7 @@ class CourseResource(Resource):
 
         schema = CourseSchema()
         course = schema.dump(query)
-        return course
+        return {"msg": "course retrieved", "course": schema.dump(course)}, 200
 
     # Removing 'course_id' will raise error when parsing
     def post(self, course_id):

--- a/restful_api/myapi/api/resources/prereq.py
+++ b/restful_api/myapi/api/resources/prereq.py
@@ -1,17 +1,20 @@
-from myapi.api.schemas import PreReqSchema
-from myapi.models import PreReq
+from flask import request
+from flask_restful import Resource
+from flask_jwt_extended import jwt_required
+from myapi.api.schemas import PrereqSchema
+from myapi.models import Prereq
+from myapi.extensions import db
+from myapi.commons.pagination import paginate
 
 # -------
 # TODO: This is a work in progress, blocked till further notice
 # -------
 def validate_prereqs(courses):
-    prereqs = PreReq.query.all()
-    prereq_schema = PreReqSchema(many=True)
+    prereqs = Prereq.query.all()
+    prereq_schema = PrereqSchema(many=True)
     prereqs = prereq_schema.dumps(prereqs).data
     
     for course in courses:
           for prereq in prereqs:
               if prereq['course_id'] == course['course_id']:
                   course['prereqs'].append(prereq)
-    
-    

--- a/restful_api/myapi/api/schemas/__init__.py
+++ b/restful_api/myapi/api/schemas/__init__.py
@@ -1,7 +1,7 @@
 from myapi.api.schemas.user import UserSchema
 from myapi.api.schemas.course import CourseSchema
 from myapi.api.schemas.employee import EmployeeSchema
-from myapi.api.schemas.pre_req import PreReqSchema
+from myapi.api.schemas.prereq import PrereqSchema
 
-__all__ = ["UserSchema", "EmployeeSchema", "CourseSchema", "PreReqSchema"]
+__all__ = ["UserSchema", "EmployeeSchema", "CourseSchema", "PrereqSchema"]
 

--- a/restful_api/myapi/api/schemas/course.py
+++ b/restful_api/myapi/api/schemas/course.py
@@ -1,12 +1,15 @@
 from myapi.models import Course
 from myapi.extensions import ma, db
 
+from .prereq import PrereqSchema
 
 class CourseSchema(ma.SQLAlchemyAutoSchema):
 
     id = ma.Int(dump_only=True)
     password = ma.String(dump_only=True)
     description = ma.String(dump_only=True)
+
+    prereqs = ma.List(ma.Nested(PrereqSchema), required=False)
     
     class Meta:
         model = Course

--- a/restful_api/myapi/api/schemas/course.py
+++ b/restful_api/myapi/api/schemas/course.py
@@ -5,10 +5,6 @@ from .prereq import PrereqSchema
 
 class CourseSchema(ma.SQLAlchemyAutoSchema):
 
-    id = ma.Int(dump_only=True)
-    password = ma.String(dump_only=True)
-    description = ma.String(dump_only=True)
-
     prereqs = ma.List(ma.Nested(PrereqSchema), required=False)
     
     class Meta:

--- a/restful_api/myapi/api/schemas/prereq.py
+++ b/restful_api/myapi/api/schemas/prereq.py
@@ -1,10 +1,10 @@
-from myapi.models import PreReq
+from myapi.models import Prereq
 from myapi.extensions import ma, db
 
 
-class PreReqSchema(ma.SQLAlchemyAutoSchema):
+class PrereqSchema(ma.SQLAlchemyAutoSchema):
     
     class Meta:
-        model = PreReq
+        model = Prereq
         sqla_session = db.session
         load_instance = True

--- a/restful_api/myapi/api/views.py
+++ b/restful_api/myapi/api/views.py
@@ -1,8 +1,15 @@
 from flask import Blueprint, current_app, jsonify
 from flask_restful import Api
 from marshmallow import ValidationError
-from myapi.api.resources import UserResource, UserList, EmployeeResource, EmployeeList, CourseList
-from myapi.api.schemas import UserSchema, EmployeeSchema, CourseSchema
+from myapi.api.resources import (
+    UserResource,
+    UserList,
+    EmployeeResource,
+    EmployeeList,
+    CourseList,
+    CourseResource
+)
+from myapi.api.schemas import UserSchema, EmployeeSchema, CourseSchema, PrereqSchema
 from myapi.extensions import apispec
 
 blueprint = Blueprint("api", __name__, url_prefix="/api/v1")
@@ -14,6 +21,7 @@ api.add_resource(UserList, "/users", endpoint="users")
 api.add_resource(CourseList, "/courses", endpoint="courses")
 api.add_resource(EmployeeList, "/employees", endpoint="employees")
 api.add_resource(EmployeeResource, "/employees/<int:employee_id>", endpoint="employee_by_id")
+api.add_resource(CourseResource, "/courses/<int:course_id>", endpoint="course")
 
 
 @blueprint.before_app_first_request
@@ -21,11 +29,13 @@ def register_views():
     apispec.spec.components.schema("UserSchema", schema=UserSchema)
     apispec.spec.components.schema("CourseSchema", schema=CourseSchema)
     apispec.spec.components.schema("EmployeeSchema", schema=EmployeeSchema)
+    apispec.spec.components.schema("PrereqSchema", schema=PrereqSchema)
     apispec.spec.path(view=UserResource, app=current_app)
     apispec.spec.path(view=UserList, app=current_app)
     apispec.spec.path(view=CourseList, app=current_app)
     apispec.spec.path(view=EmployeeResource, app=current_app)
     apispec.spec.path(view=EmployeeList, app=current_app)
+    apispec.spec.path(view=CourseResource, app=current_app)
 
 @blueprint.errorhandler(ValidationError)
 def handle_marshmallow_error(e):

--- a/restful_api/myapi/api/views.py
+++ b/restful_api/myapi/api/views.py
@@ -21,7 +21,7 @@ api.add_resource(UserList, "/users", endpoint="users")
 api.add_resource(CourseList, "/courses", endpoint="courses")
 api.add_resource(EmployeeList, "/employees", endpoint="employees")
 api.add_resource(EmployeeResource, "/employees/<int:employee_id>", endpoint="employee_by_id")
-api.add_resource(CourseResource, "/courses/<int:course_id>", endpoint="course")
+api.add_resource(CourseResource, "/course/<int:course_id>", endpoint="course")
 
 
 @blueprint.before_app_first_request

--- a/restful_api/myapi/models/__init__.py
+++ b/restful_api/myapi/models/__init__.py
@@ -2,7 +2,7 @@ from myapi.models.user import User
 from myapi.models.blocklist import TokenBlocklist
 from myapi.models.courses import Course
 from myapi.models.employee import Employee
-from myapi.models.pre_req import PreReq
+from myapi.models.prereq import Prereq
 
-__all__ = ["User", "TokenBlocklist","Employee", "Course", "PreReq"]
+__all__ = ["User", "TokenBlocklist","Employee", "Course", "Prereq"]
 

--- a/restful_api/myapi/models/pre_req.py
+++ b/restful_api/myapi/models/pre_req.py
@@ -1,9 +1,0 @@
-from myapi.extensions import db
-
-
-class PreReq(db.Model):
-    """Basic course pre-requisites model"""
-    
-    course_id = db.Column(db.Integer, primary_key=False)
-    prereq_id = db.Column(db.Integer, primary_key=False)
-

--- a/restful_api/myapi/models/prereq.py
+++ b/restful_api/myapi/models/prereq.py
@@ -1,0 +1,13 @@
+from sqlalchemy.orm import backref
+from myapi.extensions import db
+
+class Prereq(db.Model):
+    """Basic course pre-requisites model"""
+
+    __tablename__ = 'prereq'
+    __table_args__ = (db.UniqueConstraint('course_id','prereq_id', name = 'unique_course_prereq'),)
+    
+    course_id = db.Column(db.Integer, db.ForeignKey("course.course_id"), primary_key=True)
+    prereq_id = db.Column(db.Integer, primary_key=True)
+
+    course = db.relationship('Course', backref=db.backref('prereqs', lazy='joined'))

--- a/restful_api/tests/conftest.py
+++ b/restful_api/tests/conftest.py
@@ -5,11 +5,17 @@ from myapi.models import User
 from myapi.app import create_app
 from myapi.extensions import db as _db
 from pytest_factoryboy import register
-from tests.factories import UserFactory, EmployeeFactory, CourseFactory
+from tests.factories import (
+    UserFactory,
+    EmployeeFactory,
+    CourseFactory,
+    PrereqFactory
+)
 
 register(UserFactory)
 register(CourseFactory)
 register(EmployeeFactory)
+register(PrereqFactory)
 
 
 @pytest.fixture(scope="session")

--- a/restful_api/tests/factories.py
+++ b/restful_api/tests/factories.py
@@ -1,6 +1,6 @@
 import factory
 
-from myapi.models import User, Course, Employee
+from myapi.models import User, Course, Employee, Prereq
 
 
 class UserFactory(factory.Factory):
@@ -14,7 +14,7 @@ class UserFactory(factory.Factory):
 
 
 class CourseFactory(factory.Factory):
-    cid = factory.Sequence(lambda n: "%d" % n)
+    course_id = factory.Sequence(lambda n: n)
     name = factory.Sequence(lambda n: "course %d" % n)
     description = factory.Sequence(lambda n: "course %d description" % n)
 
@@ -29,3 +29,7 @@ class EmployeeFactory(factory.Factory):
     class Meta:
         model = Employee
 
+class PrereqFactory(factory.Factory):
+
+    class Meta:
+        model = Prereq

--- a/restful_api/tests/test_course.py
+++ b/restful_api/tests/test_course.py
@@ -32,7 +32,7 @@ def test_get_single_course(client, db, course_factory, admin_headers, prereq_fac
     rep = client.get(course_url, headers=admin_headers)
 
     assert rep.status_code == 200
-    assert rep.get_json()['name'] == courses[0].name
+    assert rep.get_json()['course']['name'] == courses[0].name
 
     # Add prereq to second course
     prereq_one = prereq_factory(course_id=courses[1].course_id, prereq_id=courses[0].course_id)
@@ -44,4 +44,4 @@ def test_get_single_course(client, db, course_factory, admin_headers, prereq_fac
     rep = client.get(course_url, headers=admin_headers)
 
     assert rep.status_code == 200
-    assert len(rep.get_json()['prereqs']) == 1
+    assert len(rep.get_json()['course']['prereqs']) == 1

--- a/restful_api/tests/test_course.py
+++ b/restful_api/tests/test_course.py
@@ -15,3 +15,33 @@ def test_get_all_course(client, db, course_factory, admin_headers):
     results = rep.get_json()
     for course in courses:
         assert any(c["cid"] == course.cid for c in results["results"])
+
+def test_get_single_course(client, db, course_factory, admin_headers, prereq_factory):
+    courses = course_factory.create_batch(3)
+
+    db.session.add_all(courses)
+    db.session.commit()
+
+    # Find unavailable coures
+    course_url = url_for('api.course', course_id=9999)
+    rep = client.get(course_url, headers=admin_headers)
+    assert rep.status_code == 404
+
+    # Get course without prereqs
+    course_url = url_for('api.course', course_id=courses[0].course_id)
+    rep = client.get(course_url, headers=admin_headers)
+
+    assert rep.status_code == 200
+    assert rep.get_json()['name'] == courses[0].name
+
+    # Add prereq to second course
+    prereq_one = prereq_factory(course_id=courses[1].course_id, prereq_id=courses[0].course_id)
+    db.session.add(prereq_one)
+    db.session.commit()
+
+    # Get course with prereq
+    course_url = url_for('api.course', course_id=courses[1].course_id)
+    rep = client.get(course_url, headers=admin_headers)
+
+    assert rep.status_code == 200
+    assert len(rep.get_json()['prereqs']) == 1


### PR DESCRIPTION
# Summary
Add prereqs to courses in backend.

## Changes
Add `GET api/v1/course/<int:course_id>`  and `POST api/v1/course/0` endpoints.

Modify course schema such that it **optionally** returns prereqs if exist. Should not affect current code in other branches.

The `POST` request to create course takes in exactly the same schema that `GET` outputs. No need for request parser as marshmallow handles parsing and inserting into two tables separately (Course, Prereq)

