### PR TITLE
SPM-73 Assign Trainers to Course

### DIFF
--- a/restful_api/.gitignore
+++ b/restful_api/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.vscode
 
 # C extensions
 *.so

--- a/restful_api/myapi/api/resources/__init__.py
+++ b/restful_api/myapi/api/resources/__init__.py
@@ -2,6 +2,17 @@ from myapi.api.resources.user import UserResource, UserList
 from myapi.api.resources.course import CourseList, CourseResource
 from myapi.api.resources.employee import EmployeeList, EmployeeResource
 from myapi.api.resources.official_enroll import OfficialEnrollResourceList, OfficialEnrollResource
+from myapi.api.resources.course_trainer import CourseTrainerResource
 
-__all__ = ["UserResource", "UserList", "EmployeeList", "EmployeeResource", "OfficialEnrollResourceList", "OfficialEnrollResource", "CourseList", "CourseResource"]
+__all__ = [
+  "UserResource",
+  "UserList",
+  "EmployeeList",
+  "EmployeeResource",
+  "OfficialEnrollResourceList",
+  "OfficialEnrollResource",
+  "CourseList",
+  "CourseResource",
+  "CourseTrainerResource"
+]
 

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -4,7 +4,7 @@ from flask_restful import Resource, reqparse
 from myapi.api.schemas import CourseSchema
 from myapi.commons.pagination import paginate
 from myapi.extensions import db
-from myapi.models import Course, Prereq
+from myapi.models import Course, Prereq, CourseTrainer
 
 class CourseResource(Resource):
     """Get, Create one course
@@ -45,7 +45,7 @@ class CourseResource(Resource):
                     example: course created
                   course: CourseSchema
     """
-    method_decorators = [jwt_required()]
+    # method_decorators = [jwt_required()]
 
     def get(self, course_id):
         try:
@@ -53,6 +53,7 @@ class CourseResource(Resource):
             Course.query
             .join(Prereq, isouter=True)
             .filter(Course.course_id == course_id)
+            .join(CourseTrainer, isouter=True)
             .one()
           )
         except Exception as error:

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -45,7 +45,7 @@ class CourseResource(Resource):
                     example: course created
                   course: CourseSchema
     """
-    # method_decorators = [jwt_required()]
+    method_decorators = [jwt_required()]
 
     def get(self, course_id):
         try:

--- a/restful_api/myapi/api/resources/course_trainer.py
+++ b/restful_api/myapi/api/resources/course_trainer.py
@@ -41,4 +41,4 @@ class CourseTrainerResource(Resource):
         except IntegrityError:
           return {'msg': 'invalid course trainer or course'}, 400
 
-        return {"msg": "course created", "course_trainer": schema.dump(course_trainer)}, 201
+        return {"msg": "course trainer created", "course_trainer": schema.dump(course_trainer)}, 201

--- a/restful_api/myapi/api/resources/course_trainer.py
+++ b/restful_api/myapi/api/resources/course_trainer.py
@@ -30,7 +30,7 @@ class CourseTrainerResource(Resource):
                     example: course trainer created
                   course_trainer: CourseTrainerSchema
     """
-    # method_decorators = [jwt_required()]
+    method_decorators = [jwt_required()]
 
     def post(self):
         schema = CourseTrainerSchema()

--- a/restful_api/myapi/api/resources/course_trainer.py
+++ b/restful_api/myapi/api/resources/course_trainer.py
@@ -1,0 +1,39 @@
+from flask import request
+from flask_jwt_extended import jwt_required
+from flask_restful import Resource
+from myapi.api.schemas import CourseTrainerSchema
+from myapi.extensions import db
+
+class CourseTrainerResource(Resource):
+    """Create course trainer relationship
+
+    ---
+    post:
+      tags:
+        - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              CourseTrainerSchema
+      responses:
+        201:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  msg:
+                    type: string
+                    example: course trainer created
+                  course_trainer: CourseTrainerSchema
+    """
+    # method_decorators = [jwt_required()]
+
+    def post(self):
+        schema = CourseTrainerSchema()
+        course_trainer = schema.load(request.json)
+        db.session.add(course_trainer)
+        db.session.commit()
+
+        return {"msg": "course created", "course_trainer": schema.dump(course_trainer)}, 201

--- a/restful_api/myapi/api/resources/course_trainer.py
+++ b/restful_api/myapi/api/resources/course_trainer.py
@@ -1,6 +1,8 @@
 from flask import request
 from flask_jwt_extended import jwt_required
 from flask_restful import Resource
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.exc import IntegrityError
 from myapi.api.schemas import CourseTrainerSchema
 from myapi.extensions import db
 
@@ -33,7 +35,10 @@ class CourseTrainerResource(Resource):
     def post(self):
         schema = CourseTrainerSchema()
         course_trainer = schema.load(request.json)
-        db.session.add(course_trainer)
-        db.session.commit()
+        try:
+          db.session.add(course_trainer)
+          db.session.commit()
+        except IntegrityError:
+          return {'msg': 'invalid course trainer or course'}, 400
 
         return {"msg": "course created", "course_trainer": schema.dump(course_trainer)}, 201

--- a/restful_api/myapi/api/schemas/__init__.py
+++ b/restful_api/myapi/api/schemas/__init__.py
@@ -4,7 +4,15 @@ from myapi.api.schemas.official_enroll import OfficialEnrollSchema
 from myapi.api.schemas.course import CourseSchema
 from myapi.api.schemas.employee import EmployeeSchema
 from myapi.api.schemas.prereq import PrereqSchema
+from myapi.api.schemas.course_trainer import CourseTrainerSchema
 
-__all__ = ["UserSchema", "EmployeeSchema", "CourseSchema", "PreReqSchema", "OfficialEnrollSchema"]
+__all__ = [
+  "UserSchema",
+  "EmployeeSchema",
+  "CourseSchema",
+  "PrereqSchema",
+  "OfficialEnrollSchema",
+  "CourseTrainerSchema"
+]
 
 

--- a/restful_api/myapi/api/schemas/course.py
+++ b/restful_api/myapi/api/schemas/course.py
@@ -2,10 +2,12 @@ from myapi.models import Course
 from myapi.extensions import ma, db
 
 from .prereq import PrereqSchema
+from .course_trainer import CourseTrainerSchema
 
 class CourseSchema(ma.SQLAlchemyAutoSchema):
 
     prereqs = ma.List(ma.Nested(PrereqSchema), required=False)
+    course_trainers = ma.List(ma.Nested(CourseTrainerSchema), required=False)
     
     class Meta:
         model = Course

--- a/restful_api/myapi/api/schemas/course_trainer.py
+++ b/restful_api/myapi/api/schemas/course_trainer.py
@@ -1,0 +1,14 @@
+from myapi.models.course_trainer import CourseTrainer
+from myapi.models import CourseTrainer
+from myapi.extensions import ma, db
+
+
+class CourseTrainerSchema(ma.SQLAlchemyAutoSchema):
+    
+    course_id = ma.Int()
+    trainer_id = ma.Int()
+
+    class Meta:
+        model = CourseTrainer
+        sqla_session = db.session
+        load_instance = True

--- a/restful_api/myapi/api/views.py
+++ b/restful_api/myapi/api/views.py
@@ -9,9 +9,17 @@ from myapi.api.resources import (
     CourseList,
     CourseResource,
     OfficialEnrollResource,
-    OfficialEnrollResourceList
+    OfficialEnrollResourceList,
+    CourseTrainerResource
 )
-from myapi.api.schemas import UserSchema, EmployeeSchema, CourseSchema, PrereqSchema, OfficialEnrollSchema
+from myapi.api.schemas import (
+    UserSchema,
+    EmployeeSchema,
+    CourseSchema,
+    PrereqSchema,
+    OfficialEnrollSchema,
+    CourseTrainerSchema
+)
 from myapi.extensions import apispec
 
 blueprint = Blueprint("api", __name__, url_prefix="/api/v1")
@@ -26,6 +34,7 @@ api.add_resource(OfficialEnrollResource, "/official_enroll_by_ids/<int:eng_id>&<
 api.add_resource(OfficialEnrollResourceList, "/official_enroll/<int:eng_id>", endpoint="official_enroll")
 api.add_resource(CourseList, "/courses", endpoint="courses")
 api.add_resource(CourseResource, "/course/<int:course_id>", endpoint="course")
+api.add_resource(CourseTrainerResource, "/course_trainer", endpoint="course_trainer")
 
 
 @blueprint.before_app_first_request
@@ -35,6 +44,7 @@ def register_views():
     apispec.spec.components.schema("CourseSchema", schema=CourseSchema)
     apispec.spec.components.schema("OfficialEnrollSchema", schema=OfficialEnrollSchema)
     apispec.spec.components.schema("PrereqSchema", schema=PrereqSchema)
+    apispec.spec.components.schema("CourseTrainerSchema", schema=CourseTrainerSchema)
     apispec.spec.path(view=UserResource, app=current_app)
     apispec.spec.path(view=UserList, app=current_app)
     apispec.spec.path(view=EmployeeResource, app=current_app)
@@ -43,6 +53,7 @@ def register_views():
     apispec.spec.path(view=OfficialEnrollResourceList, app=current_app)
     apispec.spec.path(view=CourseList, app=current_app)
     apispec.spec.path(view=CourseResource, app=current_app)
+    apispec.spec.path(view=CourseTrainerResource, app=current_app)
 
 @blueprint.errorhandler(ValidationError)
 def handle_marshmallow_error(e):

--- a/restful_api/myapi/manage.py
+++ b/restful_api/myapi/manage.py
@@ -10,15 +10,31 @@ def cli():
 @cli.command("init")
 @with_appcontext
 def init():
-    """Create a new admin user"""
     from myapi.extensions import db
-    from myapi.models import User
+    from myapi.models import User, Course, Prereq, Employee
 
-    # click.echo("create user")
-    # user = User(username="testuser", email="testuser@mail.com", password="testpassword", active=True)
-    # db.session.add(user)
-    # db.session.commit()
-    # click.echo("created user admin")
+    click.echo("create user")
+    user = User(id=1, username="test", email="test@mail.com", password="testpassword", active=True)
+    db.session.add(user)
+    db.session.commit()
+    click.echo("created user")
+    click.echo("create employee")
+    employee_one = Employee(id=1, name="test", user_type="ENG")
+    db.session.add(employee_one)
+    db.session.commit()
+    click.echo("created employee")
+    click.echo("create courses")
+    course_one = Course(course_id=1, description="course one description", name="course one name")
+    course_two = Course(course_id=2, description="course two description", name="course two name")
+    db.session.add(course_one)
+    db.session.add(course_two)
+    db.session.commit()
+    click.echo("created courses")
+    click.echo("create prereq")
+    prereq_one = Prereq(course_id=2, prereq_id=1)
+    db.session.add(prereq_one)
+    db.session.commit()
+    click.echo("created prereq")
 
 
 if __name__ == "__main__":

--- a/restful_api/myapi/manage.py
+++ b/restful_api/myapi/manage.py
@@ -13,28 +13,28 @@ def init():
     from myapi.extensions import db
     from myapi.models import User, Course, Prereq, Employee
 
+    items_to_add = []
     click.echo("create user")
     user = User(id=1, username="test", email="test@mail.com", password="testpassword", active=True)
-    db.session.add(user)
-    db.session.commit()
+    items_to_add.append(user)
     click.echo("created user")
     click.echo("create employee")
     employee_one = Employee(id=1, name="test", user_type="ENG")
-    db.session.add(employee_one)
-    db.session.commit()
+    items_to_add.append(employee_one)
     click.echo("created employee")
     click.echo("create courses")
     course_one = Course(course_id=1, description="course one description", name="course one name")
     course_two = Course(course_id=2, description="course two description", name="course two name")
-    db.session.add(course_one)
-    db.session.add(course_two)
-    db.session.commit()
+    items_to_add.append(course_one)
+    items_to_add.append(course_two)
     click.echo("created courses")
     click.echo("create prereq")
     prereq_one = Prereq(course_id=2, prereq_id=1)
-    db.session.add(prereq_one)
-    db.session.commit()
+    items_to_add.append(prereq_one)
     click.echo("created prereq")
+
+    db.session.add_all(items_to_add)
+    db.session.commit()
 
 
 if __name__ == "__main__":

--- a/restful_api/myapi/models/__init__.py
+++ b/restful_api/myapi/models/__init__.py
@@ -4,7 +4,8 @@ from myapi.models.employee import Employee
 from myapi.models.official_enroll import OfficialEnroll
 from myapi.models.course import Course
 from myapi.models.prereq import Prereq
+from myapi.models.course_trainer import CourseTrainer
 
-__all__ = ["User", "TokenBlocklist","Employee", "Course", "PreReq", "OfficialEnroll"]
+__all__ = ["User", "TokenBlocklist","Employee", "Course", "Prereq", "OfficialEnroll", "CourseTrainer"]
 
 

--- a/restful_api/myapi/models/course_trainer.py
+++ b/restful_api/myapi/models/course_trainer.py
@@ -1,0 +1,13 @@
+from myapi.extensions import db
+
+class CourseTrainer(db.Model):
+    """Basic course trainer model"""
+
+    __tablename__ = "course_trainer"
+    __table_args__ = (db.UniqueConstraint('course_id','trainer_id', name = 'unique_course_trainer'),)
+    
+    course_id = db.Column(db.Integer, db.ForeignKey('course.course_id'), primary_key=True)
+    trainer_id = db.Column(db.Integer, db.ForeignKey('employee.id'), primary_key=True)
+
+    course = db.relationship('Course', uselist=False, backref=db.backref('course_trainers', lazy="joined"))
+    trainer = db.relationship('Employee', uselist=False, backref=db.backref('trainer_courses', lazy="joined"))

--- a/restful_api/myapi/models/employee.py
+++ b/restful_api/myapi/models/employee.py
@@ -19,4 +19,4 @@ class Employee(db.Model):
         }
 
     def __repr__(self):
-        return "<Engineer %s>" % self.name
+        return "<Employee %s>" % self.name

--- a/restful_api/tests/conftest.py
+++ b/restful_api/tests/conftest.py
@@ -11,7 +11,8 @@ from tests.factories import (
     EmployeeFactory,
     CourseFactory,
     PrereqFactory,
-    OfficialEnrollFactory
+    OfficialEnrollFactory,
+    CourseTrainerFactory
 )
 
 register(UserFactory)
@@ -20,7 +21,7 @@ register(OfficialEnrollFactory)
 register(EmployeeFactory)
 register(PrereqFactory)
 register(CourseFactory)
-
+register(CourseTrainerFactory)
 
 @pytest.fixture(scope="session")
 def app():

--- a/restful_api/tests/factories.py
+++ b/restful_api/tests/factories.py
@@ -1,14 +1,12 @@
 import factory
 
-from myapi.models import User, Course, Employee, Prereq, OfficialEnroll
+from myapi.models import User, Course, Employee, Prereq, OfficialEnroll, CourseTrainer
 
 
 class UserFactory(factory.Factory):
-
     username = factory.Sequence(lambda n: "user%d" % n)
     email = factory.Sequence(lambda n: "user%d@mail.com" % n)
     password = "mypwd"
-
     class Meta:
         model = User
 
@@ -17,7 +15,6 @@ class CourseFactory(factory.Factory):
     course_id = factory.Sequence(lambda n: n)
     name = factory.Sequence(lambda n: "course %d" % n)
     description = factory.Sequence(lambda n: "course %d description" % n)
-
     class Meta:
         model = Course
 
@@ -36,11 +33,11 @@ class OfficialEnrollFactory(factory.Factory):
     has_passed = factory.Sequence(lambda n: False)
     class Meta:
         model = OfficialEnroll
-    
-    class Meta:
-        model = OfficialEnroll
 
 class PrereqFactory(factory.Factory):
-
     class Meta:
         model = Prereq
+
+class CourseTrainerFactory(factory.Factory):
+    class Meta:
+        model = CourseTrainer

--- a/restful_api/tests/test_course.py
+++ b/restful_api/tests/test_course.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.skip(reason="SPM-29 blocked due to lack of dependencies on other tables")
 def test_get_all_course(client, db, course_factory, admin_headers):
     course_url = url_for('api.courses')
-    courses = course_factory.create_batch(30)
+    courses = course_factory.create_batch(3)
 
     db.session.add_all(courses)
     db.session.commit()
@@ -16,7 +16,7 @@ def test_get_all_course(client, db, course_factory, admin_headers):
     for course in courses:
         assert any(c["cid"] == course.cid for c in results["results"])
 
-def test_get_single_course(client, db, course_factory, admin_headers, prereq_factory):
+def test_get_single_course_with_prereq(client, db, course_factory, admin_headers, prereq_factory):
     courses = course_factory.create_batch(3)
 
     db.session.add_all(courses)
@@ -32,7 +32,7 @@ def test_get_single_course(client, db, course_factory, admin_headers, prereq_fac
     rep = client.get(course_url, headers=admin_headers)
 
     assert rep.status_code == 200
-    assert rep.get_json()['course']['name'] == courses[0].name
+    assert rep.get_json()['course']['name'] == courses[0].name, "Incorrect course retrieved"
 
     # Add prereq to second course
     prereq_one = prereq_factory(course_id=courses[1].course_id, prereq_id=courses[0].course_id)
@@ -44,4 +44,25 @@ def test_get_single_course(client, db, course_factory, admin_headers, prereq_fac
     rep = client.get(course_url, headers=admin_headers)
 
     assert rep.status_code == 200
-    assert len(rep.get_json()['course']['prereqs']) == 1
+    assert len(rep.get_json()['course']['prereqs']) == 1, "Incorrect number of course pre-requisites"
+
+def test_get_single_course_with_trainer(
+    client,
+    db,
+    course,
+    admin_headers,
+    employee,
+    course_trainer_factory,
+):
+    course_trainer = course_trainer_factory(course_id=course.course_id, trainer_id=employee.id)
+    db.session.add(course)
+    db.session.add(employee)
+    db.session.add(course_trainer)
+    db.session.commit()
+
+    # Get course with trainer
+    course_url = url_for('api.course', course_id=course.course_id)
+    rep = client.get(course_url, headers=admin_headers)
+
+    assert rep.status_code == 200
+    assert len(rep.get_json()['course']['course_trainers']) == 1, "Incorrect number of course trainers"

--- a/restful_api/tests/test_course_trainer.py
+++ b/restful_api/tests/test_course_trainer.py
@@ -1,0 +1,12 @@
+from flask import url_for
+
+def test_add_course_trainer(client, db, course, admin_headers, employee):
+    db.session.add(course)
+    db.session.add(employee)
+    db.session.commit()
+
+    course_trainer_url = url_for('api.course_trainer')
+    data = {"trainer_id": employee.id, "course_id": course.course_id}
+    rep = client.post(course_trainer_url, json=data, headers=admin_headers)
+    assert rep.status_code == 201, "Failed to add trainer to course"
+  


### PR DESCRIPTION
## Summary
Allow assigning of trainers to course.

## Changes
- Modify `manage.py` to add sample data.
- Add `POST /api/v1/course_trainer` endpoint to add valid trainers to valid courses.
- Modify `CourseSchema` such that it optionally returns course trainers for each course in `GET /api/v1/course/<int:course_id>`.