### PR TITLE
SPM-23 [BE] Display all courses and engineer eligibility 

### DIFF
--- a/restful_api/myapi/api/resources/__init__.py
+++ b/restful_api/myapi/api/resources/__init__.py
@@ -13,6 +13,6 @@ __all__ = [
   "OfficialEnrollResource",
   "CourseList",
   "CourseResource",
-  "CourseTrainerResource"
+  "CourseTrainerResource",
 ]
 

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -90,19 +90,26 @@ class CourseList(Resource):
     get:
       tags:
         - api
+      parameters:
+        - name: eng_id
+          in: query
+          type: integer
+          required: true
+          description: engineer id
       responses:
+        400:
+          description: no engineer id provided
         200:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/PaginatedResult'
-                  - type: object
-                    properties:
-                      results:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/UserSchema'
+                type: object
+                properties:
+                  msg:
+                    type: string
+                    example: all courses retrieved
+                  result: CourseSchema
+            
     """
 
     method_decorators = [jwt_required()]
@@ -122,4 +129,4 @@ class CourseList(Resource):
       
       # Can't use paginate on this as I need to 
       # transform the data first
-      return {"msg": "all courses", "results": course_schema.dump(courses)}, 200
+      return {"msg": "all courses retrieved", "results": course_schema.dump(courses)}, 200

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -2,7 +2,7 @@
 from flask import request
 from flask_jwt_extended import jwt_required
 from flask_restful import Resource, reqparse
-from myapi.api.schemas import CourseSchema,PrereqSchema
+from myapi.api.schemas import CourseSchema,PrereqSchema, OfficialEnrollSchema
 from myapi.commons.pagination import paginate
 from myapi.extensions import db
 from myapi.models import Course, Prereq, CourseTrainer, OfficialEnroll
@@ -109,27 +109,17 @@ class CourseList(Resource):
 
     def get(self, eng_id):
       
-      all_courses = (Course.query
-               .join(
-                 OfficialEnroll.query.filter(
-                   OfficialEnroll.eng_id==eng_id
-                   ), isouter=True)
-               .join(Prereq, isouter=True)
-               )
-      
-      completed_courses = (Course.query
-               .join(
-                 OfficialEnroll.query.filter(
+      all_courses = Course.query.all()
+    
+      enrolled_courses = OfficialEnroll.query.filter(
                    OfficialEnroll.eng_id==eng_id,
-                   OfficialEnroll.has_passed == True
-                   ), isouter=True)
-               .join(Prereq, isouter=True)
-               )
+                   ).all()
       
-      schema = CourseSchema(many=True)
-      courses = validate_prereqs(schema.dump(all_courses),
-                                  schema.dump(completed_courses))
-      # print(schema.dump(completed_courses)
-      # from pprint import pprint
-      # pprint(courses))
-      return paginate(schema.load(courses), schema)
+      course_schema = CourseSchema(many=True)
+      official_enroll_schema = OfficialEnrollSchema(many=True)
+      
+      courses = validate_prereqs(all_courses, official_enroll_schema.dump(enrolled_courses))
+      
+      # Can't use paginate on this as I need to 
+      # transform the data first
+      return {"msg": "all courses", "results": course_schema.dump(courses)}, 200

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -127,6 +127,4 @@ class CourseList(Resource):
       
       courses = validate_prereqs(all_courses, official_enroll_schema.dump(enrolled_courses))
       
-      # Can't use paginate on this as I need to 
-      # transform the data first
       return {"msg": "all courses retrieved", "results": course_schema.dump(courses)}, 200

--- a/restful_api/myapi/api/resources/prereq.py
+++ b/restful_api/myapi/api/resources/prereq.py
@@ -9,24 +9,20 @@ from collections import defaultdict
 
 def validate_prereqs(courses, completed_courses):
     # convert completed courses to dict for O(1) check
-    # print(completed_courses)
-    fmted_completed_courses = {k['course_id']:1 for k in completed_courses}
-    print(fmted_completed_courses)
-    # Convert to dict for O(1) check
-    prereqs = Prereq.query.all() 
-    # Chose to query everything instead of using the MA schema to handle groupbys
+    fmted_enrolled_courses = {k['course_id']:k['has_passed'] 
+                               for k in completed_courses}
     
-    prereqs_dict = defaultdict(list)
-    for preq in prereqs:
-        prereqs_dict[preq.course_id].append(preq.prereq_id)
-    
-    # check if each course has prereqs
+    # Check the pre-reqs to see if they are done
     for course in courses:
         completed = 0
-        for cid in prereqs_dict[course['course_id']]:
-            completed += fmted_completed_courses[cid]
+        for preq in course.prereqs:
+            completed += fmted_enrolled_courses.get(preq.prereq_id, 0)
             
-        course['is_eligible'] = completed == len(prereqs_dict[course['course_id']])
-            
+        course.is_eligible = completed == len(course.prereqs) 
+
+        if course.course_id in fmted_enrolled_courses:
+            # only create the attribute if it is inside
+            course.has_passed = fmted_enrolled_courses.get(course.course_id, None)
+        
     return courses
    

--- a/restful_api/myapi/api/resources/prereq.py
+++ b/restful_api/myapi/api/resources/prereq.py
@@ -1,12 +1,3 @@
-from flask import request
-from flask_restful import Resource
-from flask_jwt_extended import jwt_required
-from myapi.api.schemas import PrereqSchema
-from myapi.models import Prereq
-from myapi.extensions import db
-from myapi.commons.pagination import paginate
-from collections import defaultdict
-
 def validate_prereqs(courses, completed_courses):
     # convert completed courses to dict for O(1) check
     fmted_enrolled_courses = {k['course_id']:k['has_passed'] 

--- a/restful_api/myapi/api/schemas/course.py
+++ b/restful_api/myapi/api/schemas/course.py
@@ -1,35 +1,34 @@
 from myapi.models import Course
 from myapi.extensions import ma, db
-from marshmallow import fields
 from .prereq import PrereqSchema
 from .course_trainer import CourseTrainerSchema
-
 class CourseSchema(ma.SQLAlchemyAutoSchema):
 
     prereqs = ma.List(ma.Nested(PrereqSchema), required=False)
     course_trainers = ma.List(ma.Nested(CourseTrainerSchema), required=False)
-    isEligible = fields.Method('is_eligible') # Note, this is using Marshmallow, not the flask extension
-    isActive = fields.Method('is_active')
-    isComplete = fields.Method('is_complete')
+    isEligible = ma.Method('is_eligible') # Note, this is using Marshmallow, not the flask extension
+    isActive = ma.Method('is_active')
+    isComplete = ma.Method('is_complete')
     class Meta:
         model = Course
         sqla_session = db.session
         load_instance = True
         ordered = True
+        
     
     def is_complete(self, obj):
         if hasattr(obj, 'has_passed'):
             return obj.has_passed
-        return None
+        return False
     
     def is_eligible(self, obj):
         if hasattr(obj, 'is_eligible'):
             return obj.is_eligible
-        return None
+        return False
     
     def is_active(self, obj):
         # If enrolled but haven't passed, then it's active
         # Hence, not has passed.
         if hasattr(obj, 'has_passed'):
             return not obj.has_passed
-        return None
+        return False

--- a/restful_api/myapi/api/schemas/course.py
+++ b/restful_api/myapi/api/schemas/course.py
@@ -1,6 +1,6 @@
 from myapi.models import Course
 from myapi.extensions import ma, db
-
+from marshmallow import fields
 from .prereq import PrereqSchema
 from .course_trainer import CourseTrainerSchema
 
@@ -8,8 +8,28 @@ class CourseSchema(ma.SQLAlchemyAutoSchema):
 
     prereqs = ma.List(ma.Nested(PrereqSchema), required=False)
     course_trainers = ma.List(ma.Nested(CourseTrainerSchema), required=False)
-    
+    isEligible = fields.Method('is_eligible') # Note, this is using Marshmallow, not the flask extension
+    isActive = fields.Method('is_active')
+    isComplete = fields.Method('is_complete')
     class Meta:
         model = Course
         sqla_session = db.session
         load_instance = True
+        ordered = True
+    
+    def is_complete(self, obj):
+        if hasattr(obj, 'has_passed'):
+            return obj.has_passed
+        return None
+    
+    def is_eligible(self, obj):
+        if hasattr(obj, 'is_eligible'):
+            return obj.is_eligible
+        return None
+    
+    def is_active(self, obj):
+        # If enrolled but haven't passed, then it's active
+        # Hence, not has passed.
+        if hasattr(obj, 'has_passed'):
+            return not obj.has_passed
+        return None

--- a/restful_api/myapi/api/schemas/course.py
+++ b/restful_api/myapi/api/schemas/course.py
@@ -6,7 +6,7 @@ class CourseSchema(ma.SQLAlchemyAutoSchema):
 
     prereqs = ma.List(ma.Nested(PrereqSchema), required=False)
     course_trainers = ma.List(ma.Nested(CourseTrainerSchema), required=False)
-    isEligible = ma.Method('is_eligible') # Note, this is using Marshmallow, not the flask extension
+    isEligible = ma.Method('is_eligible')
     isActive = ma.Method('is_active')
     isComplete = ma.Method('is_complete')
     class Meta:
@@ -15,7 +15,6 @@ class CourseSchema(ma.SQLAlchemyAutoSchema):
         load_instance = True
         ordered = True
         
-    
     def is_complete(self, obj):
         if hasattr(obj, 'has_passed'):
             return obj.has_passed

--- a/restful_api/myapi/api/views.py
+++ b/restful_api/myapi/api/views.py
@@ -32,7 +32,7 @@ api.add_resource(EmployeeList, "/employees", endpoint="employees")
 api.add_resource(EmployeeResource, "/employees/<int:employee_id>", endpoint="employee_by_id")
 api.add_resource(OfficialEnrollResource, "/official_enroll_by_ids/<int:eng_id>&<int:course_id>", endpoint="official_enroll_by_ids")
 api.add_resource(OfficialEnrollResourceList, "/official_enroll/<int:eng_id>", endpoint="official_enroll")
-api.add_resource(CourseList, "/courses", endpoint="courses")
+api.add_resource(CourseList, "/courses/<int:eng_id>", endpoint="courses")
 api.add_resource(CourseResource, "/course/<int:course_id>", endpoint="course")
 api.add_resource(CourseTrainerResource, "/course_trainer", endpoint="course_trainer")
 

--- a/restful_api/myapi/models/course.py
+++ b/restful_api/myapi/models/course.py
@@ -4,7 +4,8 @@ from myapi.extensions import db
 class Course(db.Model):
     """Basic course model"""
     
+    __tablename__ = 'course'
+    
     course_id = db.Column(db.Integer, primary_key=True)
     description = db.Column(db.String(255), nullable=False)
     name = db.Column(db.String(255), nullable=False)
-    

--- a/restful_api/myapi/models/official_enroll.py
+++ b/restful_api/myapi/models/official_enroll.py
@@ -4,6 +4,7 @@ class OfficialEnroll(db.Model):
     """Basic official enroll model"""
 
     __tablename__ = "official_enroll"
+    __table_args__ = (db.UniqueConstraint('eng_id','course_id', name = 'unique_official_enroll'),)
     
     eng_id = db.Column(db.Integer, db.ForeignKey('employee.id'), primary_key=True)
     course_id = db.Column(db.Integer, db.ForeignKey('course.course_id'), primary_key=True)

--- a/restful_api/tests/test_course.py
+++ b/restful_api/tests/test_course.py
@@ -1,21 +1,6 @@
 from flask import url_for
 import pytest
 
-@pytest.mark.skip(reason="SPM-29 blocked due to lack of dependencies on other tables")
-def test_get_all_course(client, db, course_factory, admin_headers):
-    course_url = url_for('api.courses')
-    courses = course_factory.create_batch(3)
-
-    db.session.add_all(courses)
-    db.session.commit()
-
-    rep = client.get(course_url, headers=admin_headers)
-    assert rep.status_code == 200
-
-    results = rep.get_json()
-    for course in courses:
-        assert any(c["cid"] == course.cid for c in results["results"])
-
 def test_get_single_course_with_prereq(client, db, course_factory, admin_headers, prereq_factory):
     courses = course_factory.create_batch(3)
 
@@ -66,3 +51,38 @@ def test_get_single_course_with_trainer(
 
     assert rep.status_code == 200
     assert len(rep.get_json()['course']['course_trainers']) == 1, "Incorrect number of course trainers"
+
+@pytest.mark.bran
+def test_get_eligible_courses(
+    client,
+    db,
+    admin_headers,
+    employee,
+    course_factory, 
+    prereq_factory,
+    official_enroll_factory,
+    ):
+    
+    # Create the courses
+    courses = course_factory.create_batch(5)
+    
+    # Let course 0 be the base the other courses rely on
+    enroll_one = official_enroll_factory(course_id=courses[0].course_id, has_passed=True, eng_id=employee.id)
+    
+    # Add the pre-reqs to the courses
+    prereq_one = prereq_factory(course_id=courses[1].course_id, prereq_id=courses[0].course_id)
+    prereq_two = prereq_factory(course_id=courses[2].course_id, prereq_id=courses[1].course_id)
+    
+    db.session.add_all(courses)
+    db.session.add_all([employee])
+    db.session.add_all([prereq_one, prereq_two])
+    db.session.add_all([enroll_one])
+    
+    db.session.commit()
+
+    # Get all courses
+    course_url = url_for('api.courses', eng_id=employee.id)
+    rep = client.get(course_url, headers=admin_headers)
+    print(rep.get_json())
+    assert rep.status_code == 200
+    assert len(rep.get_json()['courses']) == 2, "Incorrect number of courses"


### PR DESCRIPTION
# Summary

Display all courses with fields to indicate if engineer is eligible for course, if course is active or completed. (@edwinlzs may wish to take note)

# Changes

1. Modified marshmallow schema for course, to add custom fields when dumping
2. `resources/prereq.py` has a helper function to check for eligibility, it is not an endpoint
3. New dependency created, this endpoint relies on marshmallow schema of nesting the prerequisites into the prerequisites field.

# Note

After this branch is completed, I'll create a PR for SPM-29 into release 1, it's very big, due to many tickets being branched from SPM-29. 

Do note that SPM-29 is actually meant to be SPM-23, I saw the wrong ticket. SPM-29 is the FE version, SPM-23 is the BE.

