### PR TITLE
SPM-79 Delete course API

### DIFF
--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -45,6 +45,20 @@ class CourseResource(Resource):
                     type: string
                     example: course created
                   course: CourseSchema
+
+    delete:
+      tags:
+        - api
+      responses: 
+        204:
+          description: The resource was deleted successfully.
+        404:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
     """
     # method_decorators = [jwt_required()]
 

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -60,7 +60,7 @@ class CourseResource(Resource):
                 properties:
                   message: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
     """
-    # method_decorators = [jwt_required()]
+    method_decorators = [jwt_required()]
 
     def get(self, course_id):
         try:

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -46,7 +46,7 @@ class CourseResource(Resource):
                     example: course created
                   course: CourseSchema
     """
-    method_decorators = [jwt_required()]
+    # method_decorators = [jwt_required()]
 
     def get(self, course_id):
         try:
@@ -81,6 +81,14 @@ class CourseResource(Resource):
             raise error
 
         return {"msg": "course created", "course": schema.dump(course)}, 201
+
+    def delete(self, course_id):
+        course = Course.query.get_or_404(course_id)
+        db.session.delete(course)
+        db.session.commit()
+
+        return {"msg": "course deleted"}, 204
+
 
 
 class CourseList(Resource):

--- a/restful_api/myapi/manage.py
+++ b/restful_api/myapi/manage.py
@@ -11,16 +11,27 @@ def cli():
 @with_appcontext
 def init():
     from myapi.extensions import db
-    from myapi.models import User, Course, Prereq, Employee
+    from myapi.models import (
+        User,
+        Course,
+        Prereq,
+        Employee,
+        CourseTrainer,
+        OfficialEnroll
+    )
 
     items_to_add = []
     click.echo("create user")
-    user = User(id=1, username="testuser", email="test@mail.com", password="testpassword", active=True)
-    items_to_add.append(user)
+    user_one = User(id=1, username="testuser", email="test@mail.com", password="testpassword", active=True)
+    user_two = User(id=2, username="testtrainer", email="trainer@mail.com", password="trainerpassword", active=True)
+    items_to_add.append(user_one)
+    items_to_add.append(user_two)
     click.echo("created user")
     click.echo("create employee")
-    employee_one = Employee(id=1, name="test", user_type="ENG")
+    employee_one = Employee(id=1, name="testuser", user_type="ENG")
+    employee_two = Employee(id=2, name="testtrainer", user_type="ENG")
     items_to_add.append(employee_one)
+    items_to_add.append(employee_two)
     click.echo("created employee")
     click.echo("create courses")
     course_one = Course(course_id=1, description="course one description", name="course one name")
@@ -32,9 +43,29 @@ def init():
     prereq_one = Prereq(course_id=2, prereq_id=1)
     items_to_add.append(prereq_one)
     click.echo("created prereq")
+    click.echo("create course trainer")
+    course_trainer_one = CourseTrainer(course_id=2, trainer_id=2)
+    course_trainer_two = CourseTrainer(course_id=1, trainer_id=2)
+    items_to_add.append(course_trainer_one)
+    items_to_add.append(course_trainer_two)
+    click.echo("created course trainer")
+    click.echo("create official enrol")
+    official_enrol_one = OfficialEnroll(eng_id=1, course_id=2)
+    items_to_add.append(official_enrol_one)
+    click.echo("created official enrol")
 
     db.session.add_all(items_to_add)
     db.session.commit()
+
+@cli.command("reset")
+@with_appcontext
+def reset():
+    """Deletes all the data from tables
+    """
+    from myapi.extensions import db
+    db.session.commit()
+    db.drop_all()
+    db.create_all()
 
 
 if __name__ == "__main__":

--- a/restful_api/myapi/models/course_trainer.py
+++ b/restful_api/myapi/models/course_trainer.py
@@ -9,5 +9,5 @@ class CourseTrainer(db.Model):
     course_id = db.Column(db.Integer, db.ForeignKey('course.course_id'), primary_key=True)
     trainer_id = db.Column(db.Integer, db.ForeignKey('employee.id'), primary_key=True)
 
-    course = db.relationship('Course', uselist=False, backref=db.backref('course_trainers', lazy="joined"))
-    trainer = db.relationship('Employee', uselist=False, backref=db.backref('trainer_courses', lazy="joined"))
+    course = db.relationship('Course', uselist=False, backref=db.backref('course_trainers', lazy="joined", cascade="all,delete"))
+    trainer = db.relationship('Employee', uselist=False, backref=db.backref('trainer_courses', lazy="joined", cascade="all,delete"))

--- a/restful_api/myapi/models/official_enroll.py
+++ b/restful_api/myapi/models/official_enroll.py
@@ -11,3 +11,6 @@ class OfficialEnroll(db.Model):
     start_date = db.Column(db.DateTime)
     end_date = db.Column(db.DateTime)
     has_passed = db.Column(db.Boolean, default=False)
+
+    # If course is deleted, the row in this table will be dropped
+    course = db.relationship('Course', backref=db.backref('official_enrols', lazy='joined', cascade="all,delete"))

--- a/restful_api/myapi/models/prereq.py
+++ b/restful_api/myapi/models/prereq.py
@@ -10,4 +10,4 @@ class Prereq(db.Model):
     course_id = db.Column(db.Integer, db.ForeignKey("course.course_id"), primary_key=True)
     prereq_id = db.Column(db.Integer, primary_key=True)
 
-    course = db.relationship('Course', backref=db.backref('prereqs', lazy='joined'))
+    course = db.relationship('Course', backref=db.backref('prereqs', lazy='joined', cascade="all,delete"))

--- a/restful_api/tests/test_course.py
+++ b/restful_api/tests/test_course.py
@@ -40,12 +40,12 @@ def test_delete_single_course(client, db, course, admin_headers):
     # Delete course success
     course_url = url_for('api.course', course_id=course.course_id)
     rep = client.delete(course_url, headers=admin_headers)
-    assert rep.status_code == 204
+    assert rep.status_code == 204, "Incorrect response code"
 
     # Delete course failure
     course_url = url_for('api.course', course_id=9999)
     rep = client.delete(course_url, headers=admin_headers)
-    assert rep.status_code == 404
+    assert rep.status_code == 404, "Incorrect response code"
 
 def test_delete_single_course_drop_cascade(
     client,
@@ -71,10 +71,10 @@ def test_delete_single_course_drop_cascade(
     # Delete course success
     course_url = url_for('api.course', course_id=courses[0].course_id)
     rep = client.delete(course_url, headers=admin_headers)
-    assert rep.status_code == 204
+    assert rep.status_code == 204, "Incorrect response code"
 
-    assert db.session.query(Prereq.course_id).filter_by(course_id=courses[0].course_id).first() is None
-    assert db.session.query(CourseTrainer.course_id).filter_by(course_id=courses[0].course_id).first() is  None
+    assert db.session.query(Prereq.course_id).filter_by(course_id=courses[0].course_id).first() is None, "Fail to delete cascade course prereq"
+    assert db.session.query(CourseTrainer.course_id).filter_by(course_id=courses[0].course_id).first() is  None, "Fail to delete cascade course trainer"
 
 
 def test_get_single_course_with_trainer(

--- a/restful_api/tests/test_course.py
+++ b/restful_api/tests/test_course.py
@@ -1,5 +1,7 @@
 from flask import url_for
-import pytest
+
+from myapi.models.prereq import Prereq
+from myapi.models.course_trainer import CourseTrainer
 
 def test_get_single_course_with_prereq(client, db, course_factory, admin_headers, prereq_factory):
     courses = course_factory.create_batch(3)
@@ -30,6 +32,50 @@ def test_get_single_course_with_prereq(client, db, course_factory, admin_headers
 
     assert rep.status_code == 200
     assert len(rep.get_json()['course']['prereqs']) == 1, "Incorrect number of course pre-requisites"
+
+def test_delete_single_course(client, db, course, admin_headers):
+    db.session.add(course)
+    db.session.commit()
+
+    # Delete course success
+    course_url = url_for('api.course', course_id=course.course_id)
+    rep = client.delete(course_url, headers=admin_headers)
+    assert rep.status_code == 204
+
+    # Delete course failure
+    course_url = url_for('api.course', course_id=9999)
+    rep = client.delete(course_url, headers=admin_headers)
+    assert rep.status_code == 404
+
+def test_delete_single_course_drop_cascade(
+    client,
+    db,
+    course_factory,
+    admin_headers,
+    prereq_factory,
+    employee,
+    course_trainer_factory
+    ):
+    """Tests if deleting a course drop-cascades foreign keys"""
+    courses = course_factory.create_batch(2)
+    prereq_one = prereq_factory(course_id=courses[0].course_id, prereq_id=courses[1].course_id)
+    course_trainer = course_trainer_factory(course_id=courses[0].course_id, trainer_id=employee.id)
+
+    db.session.add_all(courses)
+    db.session.add_all([employee, prereq_one, course_trainer])
+    db.session.commit()
+
+    assert db.session.query(Prereq.course_id).filter_by(course_id=courses[0].course_id).first() is not None
+    assert db.session.query(CourseTrainer.course_id).filter_by(course_id=courses[0].course_id).first() is not None
+
+    # Delete course success
+    course_url = url_for('api.course', course_id=courses[0].course_id)
+    rep = client.delete(course_url, headers=admin_headers)
+    assert rep.status_code == 204
+
+    assert db.session.query(Prereq.course_id).filter_by(course_id=courses[0].course_id).first() is None
+    assert db.session.query(CourseTrainer.course_id).filter_by(course_id=courses[0].course_id).first() is  None
+
 
 def test_get_single_course_with_trainer(
     client,


### PR DESCRIPTION
## Summary
API to delete course at `DELETE /api/v1/course/<int:course_id>`

## Changes
Add more items to autopopulate DB in `manage.py`.

Add foreign key links from `Course` to `Prereq`, `CourseTrainer`, `OfficialEnrol`.

Add `flask myapi reset` command to reset the database.