### PR TITLE
SPM-44 Engineers Enroll Timestamp

### DIFF
--- a/restful_api/myapi/api/resources/__init__.py
+++ b/restful_api/myapi/api/resources/__init__.py
@@ -2,7 +2,7 @@ from myapi.api.resources.user import UserResource, UserList
 
 from myapi.api.resources.course import CourseList, CourseResource
 from myapi.api.resources.employee import EmployeeList, EmployeeResource
-from myapi.api.resources.enroll import EnrollResourceList, EnrollResource
+from myapi.api.resources.enroll import EnrollResourceList, EnrollResource, EnrollByCourseResourceList
 from myapi.api.resources.course_class import CourseClassResource
 from myapi.api.resources.class_section import ClassSectionResource, ClassSectionResourceList
 
@@ -14,6 +14,7 @@ __all__ = [
     "EmployeeResource",
     "EnrollResourceList",
     "EnrollResource",
+    "EnrollByCourseResourceList",
     "CourseList",
     "CourseResource",
     "CourseClassResource",

--- a/restful_api/myapi/api/resources/enroll.py
+++ b/restful_api/myapi/api/resources/enroll.py
@@ -152,3 +152,34 @@ class EnrollResourceList(Resource):
     def get(self, eng_id):
         query = Enroll.query.filter_by(eng_id=eng_id)
         return paginate(query, self.schema)
+
+
+class EnrollByCourseResourceList(Resource):
+    """Get all enrolled courses based on course id
+
+    ---
+    get:
+      tags:
+        - api
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PaginatedResult'
+                  - type: object
+                    properties:
+                      results:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/EnrollSchema'
+    """
+    method_decorators = [jwt_required()]
+
+    def __init__(self):
+        self.schema = EnrollSchema(many=True)
+
+    def get(self, course_id):
+        query = Enroll.query.filter_by(course_id=course_id).order_by(Enroll.created_timestamp.desc())
+        return paginate(query, self.schema)

--- a/restful_api/myapi/api/schemas/enroll.py
+++ b/restful_api/myapi/api/schemas/enroll.py
@@ -11,6 +11,7 @@ class EnrollSchema(ma.SQLAlchemyAutoSchema):
     trainer_id = ma.Int()
     has_passed = ma.Boolean()
     is_official = ma.Boolean()
+    created_timestamp = ma.Int()
 
     course = ma.Nested(CourseSchema, required=False)
     trainer = ma.Nested(EmployeeSchema, required=False)

--- a/restful_api/myapi/api/views.py
+++ b/restful_api/myapi/api/views.py
@@ -13,6 +13,7 @@ from myapi.api.resources import (
     ClassSectionResourceList,
     EnrollResource,
     EnrollResourceList,
+    EnrollByCourseResourceList
 )
 from myapi.api.schemas import (
     UserSchema,
@@ -36,6 +37,7 @@ api.add_resource(EmployeeList, "/employees", endpoint="employees")
 api.add_resource(EmployeeResource, "/employees/<int:employee_id>", endpoint="employee_by_id")
 api.add_resource(EnrollResource, "/enroll/<int:eng_id>&<int:course_id>&<int:trainer_id>", endpoint="enrollment")
 api.add_resource(EnrollResourceList, "/enrollments/<int:eng_id>", endpoint="enrollments")
+api.add_resource(EnrollByCourseResourceList, "/enrollments_by_course/<int:course_id>", endpoint="enrollments_by_course")
 api.add_resource(CourseList, "/courses/<int:eng_id>", endpoint="courses")
 api.add_resource(CourseResource, "/course/<int:course_id>", endpoint="course")
 api.add_resource(CourseClassResource, "/course_class/<int:course_id>&<int:trainer_id>", endpoint="course_class")
@@ -65,6 +67,7 @@ def handle_marshmallow_error(e):
     apispec.spec.path(view=EmployeeList, app=current_app)
     apispec.spec.path(view=EnrollResource, app=current_app)
     apispec.spec.path(view=EnrollResourceList, app=current_app)
+    apispec.spec.path(view=EnrollByCourseResourceList, app=current_app)
     apispec.spec.path(view=CourseResource, app=current_app)
     apispec.spec.path(view=CourseClassResource, app=current_app)
     apispec.spec.path(view=ClassSectionResource, app=current_app)

--- a/restful_api/myapi/models/enroll.py
+++ b/restful_api/myapi/models/enroll.py
@@ -12,6 +12,7 @@ class Enroll(db.Model):
     trainer_id = db.Column(db.Integer, db.ForeignKey('employee.id'), primary_key=True)
     has_passed = db.Column(db.Boolean, default=False, nullable=False)
     is_official = db.Column(db.Boolean, default=False, nullable=False)
+    created_timestamp = db.Column(db.Integer)
 
     course = db.relationship('Course', backref=db.backref('enrollment_course', lazy='joined', cascade="all,delete"))
 

--- a/restful_api/tests/factories.py
+++ b/restful_api/tests/factories.py
@@ -1,4 +1,5 @@
 import factory
+import time
 
 from myapi.models import (
     User,
@@ -44,6 +45,7 @@ class EnrollFactory(factory.Factory):
     trainer_id = factory.SelfAttribute('trainer.id')
     has_passed = factory.LazyAttribute(lambda n: False)
     is_official = factory.LazyAttribute(lambda n: False)
+    created_timestamp = factory.LazyFunction(time.time)
 
     eng = factory.SubFactory(EmployeeFactory)
     course = factory.SubFactory(CourseFactory)


### PR DESCRIPTION
### Summary 
When an enrollment is created, a timestamp will be created together with the enrollment record to allow FE to sort enrolled engineers of a course based on enrollment timestamp

### Changes
Added `created_timestamp` field to Enroll model. `created_timestamp` is type `Integer` (unix timestamp in seconds)

Created `GET enrollments_by_course` endpoint to retrieve list of enrollments by course for SPM-44, sorted by `created_timestamp` desc 

Added `created_timestamp=LazyFunction(time.time)` to EnrollFactory 

