### PR TITLE
SMP-62 retrieve engineer progress across courses

### DIFF
--- a/restful_api/myapi/api/resources/__init__.py
+++ b/restful_api/myapi/api/resources/__init__.py
@@ -3,7 +3,7 @@ from myapi.api.resources.employee import EmployeeList, EmployeeResource
 from myapi.api.resources.enroll import EnrollResourceList, EnrollResource, EnrollByEngineerSelfResourceList, EnrollByCourseResourceList
 from myapi.api.resources.course_class import CourseClassResource
 from myapi.api.resources.class_section import ClassSectionResource, ClassSectionResourceList
-
+from myapi.api.resources.progress import ProgressResource
 
 __all__ = [
     "EmployeeList",
@@ -16,5 +16,6 @@ __all__ = [
     "CourseResource",
     "CourseClassResource",
     "ClassSectionResource",
-    "ClassSectionResourceList"
+    "ClassSectionResourceList",
+    "ProgressResource"
 ]

--- a/restful_api/myapi/api/resources/progress.py
+++ b/restful_api/myapi/api/resources/progress.py
@@ -24,7 +24,7 @@ class ProgressResource(Resource):
                     progress:
                       type: object
                       example:
-                        <course_id>: 
+                        <course_id>:
                           no_sections: 4
                           completed_sections: 3
                           pct_completed: 0.75

--- a/restful_api/myapi/api/resources/progress.py
+++ b/restful_api/myapi/api/resources/progress.py
@@ -27,7 +27,6 @@ class ProgressResource(Resource):
                         <course_id>:
                           no_sections: 4
                           completed_sections: 3
-                          pct_completed: 0.75
           404:
             content:
               application/json:

--- a/restful_api/myapi/api/resources/progress.py
+++ b/restful_api/myapi/api/resources/progress.py
@@ -1,0 +1,74 @@
+import json
+from flask_jwt_extended import jwt_required
+from flask_restful import Resource
+from myapi.api.schemas import EnrollSchema
+from myapi.models import ClassSection, Enroll, SectionCompleted
+
+
+class ProgressResource(Resource):
+    """Single object employee progress resource
+    ---
+    get:
+        tags:
+          - api
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    msg:
+                      type: string
+                      example: engineer progress retrieved
+                    progress:
+                      type: object
+                      example:
+                        <course_id>: 
+                          no_sections: 4
+                          completed_sections: 3
+                          pct_completed: 0.75
+          404:
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    msg: engineer has no enrolled courses
+    """
+
+    method_decorators = [jwt_required()]
+
+    def get(self, eng_id):
+        query = Enroll.query.filter(Enroll.eng_id == eng_id).all()
+        courses_taken = EnrollSchema(many=True).dump(query)
+        result = {}
+
+        if not courses_taken:
+            return {"msg": "engineer has no enrolled courses"}, 404
+
+        for c in courses_taken:
+            num_sections = (ClassSection.query
+                            .filter_by(
+                                course_id=c['course_id'],
+                                trainer_id=c['trainer_id']
+                            )
+                            .count()
+                            )
+
+            num_completed_sections = (SectionCompleted.query
+                                      .filter_by(
+                                          course_id=c['course_id'],
+                                          trainer_id=c['trainer_id'],
+                                          eng_id=c['eng_id']
+                                      )
+                                      .count()
+                                      )
+
+            result[c['course_id']] = {
+                "no_sections": num_sections,
+                "completed_sections": num_completed_sections,
+                "pct_completed": num_completed_sections / num_sections
+            }
+
+        return {"msg": "engineer progress retrieved", "progress": json.dumps(result)}, 200

--- a/restful_api/myapi/api/resources/progress.py
+++ b/restful_api/myapi/api/resources/progress.py
@@ -68,7 +68,6 @@ class ProgressResource(Resource):
             result[c['course_id']] = {
                 "no_sections": num_sections,
                 "completed_sections": num_completed_sections,
-                "pct_completed": num_completed_sections / num_sections
             }
 
         return {"msg": "engineer progress retrieved", "progress": json.dumps(result)}, 200

--- a/restful_api/myapi/api/views.py
+++ b/restful_api/myapi/api/views.py
@@ -12,7 +12,8 @@ from myapi.api.resources import (
     EnrollResource,
     EnrollResourceList,
     EnrollByEngineerSelfResourceList,
-    EnrollByCourseResourceList
+    EnrollByCourseResourceList,
+    ProgressResource
 )
 from myapi.api.schemas import (
     EmployeeSchema,
@@ -40,6 +41,7 @@ api.add_resource(CourseResource, "/course/<int:course_id>", endpoint="course")
 api.add_resource(CourseClassResource, "/course_class/<int:course_id>&<int:trainer_id>", endpoint="course_class")
 api.add_resource(ClassSectionResource, "/class_section/<int:section_id>", endpoint="class_section")
 api.add_resource(ClassSectionResourceList, "/class_sections/<int:course_id>&<int:trainer_id>&<int:eng_id>", endpoint="class_sections_by_course")
+api.add_resource(ProgressResource, "/progress/<int:eng_id>", endpoint="progress")
 
 
 @blueprint.before_app_first_request
@@ -61,6 +63,7 @@ def register_views():
     apispec.spec.path(view=CourseResource, app=current_app)
     apispec.spec.path(view=CourseClassResource, app=current_app)
     apispec.spec.path(view=ClassSectionResource, app=current_app)
+    apispec.spec.path(view=ProgressResource, app=current_app)
 
 
 @blueprint.errorhandler(ValidationError)

--- a/restful_api/tests/test_progress.py
+++ b/restful_api/tests/test_progress.py
@@ -1,0 +1,61 @@
+from flask import url_for
+import json
+
+
+def test_get_employee_progress(
+    client,
+    db,
+    employee,
+    course_class,
+    class_section_factory,
+    section_completed_factory,
+    engineer_employee_headers,
+    enroll_factory
+):
+
+    sections = [class_section_factory(course_class=course_class) for _ in range(4)]
+    completed_sections = [section_completed_factory(class_section=sections[i], engineer=employee) for i in range(3)]
+    enrollment = enroll_factory(course_id=course_class.course_id,
+                                trainer_id=course_class.course_id,
+                                eng=employee,
+                                trainer=course_class.trainer,
+                                course=course_class.course)
+
+    db.session.add_all(completed_sections + sections + [employee, enrollment])
+    db.session.commit()
+
+    progress_url = url_for('api.progress', eng_id=employee.id)
+    rep = client.get(progress_url, headers=engineer_employee_headers)
+    assert rep.status_code == 200
+    json_payload = json.loads(rep.get_json()['progress'])
+    assert json_payload[str(course_class.course_id)]['pct_completed'] == 3 / 4
+
+    completed_section_4 = section_completed_factory(class_section=sections[-1], engineer=employee)
+    db.session.add(completed_section_4)
+    db.session.commit()
+
+    progress_url = url_for('api.progress', eng_id=employee.id)
+    rep = client.get(progress_url, headers=engineer_employee_headers)
+    assert rep.status_code == 200
+    json_payload = json.loads(rep.get_json()['progress'])
+    assert json_payload[str(course_class.course_id)]['pct_completed'] == 4 / 4
+
+
+def test_get_employee_with_no_enrollment(
+    client,
+    db,
+    employee,
+    course_class,
+    class_section_factory,
+    section_completed_factory,
+    engineer_employee_headers,
+):
+
+    sections = [class_section_factory(course_class=course_class) for _ in range(4)]
+    completed_sections = [section_completed_factory(class_section=sections[i], engineer=employee) for i in range(3)]
+    db.session.add_all(completed_sections + sections + [employee])
+    db.session.commit()
+
+    progress_url = url_for('api.progress', eng_id=employee.id)
+    rep = client.get(progress_url, headers=engineer_employee_headers)
+    assert rep.status_code == 404


### PR DESCRIPTION
# Summary

Create endpoint to get engineer progress. Checks `Enroll` table for `course_id` & `trainer_id` then queries for num of section in class, and num completed classes by engineer. Returns a float, which is % completion.

# Changes
1. Create `progress.py`
2. Create `test_progress.py`
3. No other files were affected