### PR TITLE
SPM-37 view course progress

### DIFF
--- a/restful_api/myapi/api/resources/__init__.py
+++ b/restful_api/myapi/api/resources/__init__.py
@@ -4,7 +4,7 @@ from myapi.api.resources.enroll import EnrollResourceList, EnrollResource, Enrol
 from myapi.api.resources.course_class import CourseClassResource
 from myapi.api.resources.class_section import ClassSectionResource, ClassSectionResourceList
 from myapi.api.resources.quiz import QuizResourceList, QuizResource
-from myapi.api.resources.progress import ProgressResource
+from myapi.api.resources.progress import ProgressResource, ProgressListResource
 
 __all__ = [
     "EmployeeList",
@@ -20,5 +20,6 @@ __all__ = [
     "ClassSectionResourceList",
     "QuizResource",
     "QuizResourceList",
-    "ProgressResource"
+    "ProgressResource",
+    "ProgressListResource"
 ]

--- a/restful_api/myapi/api/resources/progress.py
+++ b/restful_api/myapi/api/resources/progress.py
@@ -1,4 +1,3 @@
-import json
 from flask_jwt_extended import jwt_required
 from flask_restful import Resource
 from myapi.api.schemas import EnrollSchema
@@ -47,14 +46,15 @@ class ProgressResource(Resource):
                                   )
                                   .count()
                                   )
-        
+
         result = {
-          "no_sections": num_sections,
-          "completed_sections": num_completed_sections
+            "no_sections": num_sections,
+            "completed_sections": num_completed_sections
         }
 
-        return {"msg": "engineer course progress retrieved", "progress": result}, 
-      
+        return {"msg": "engineer course progress retrieved", "progress": result},
+
+
 class ProgressListResource(Resource):
     """Multiple object employee progress resource
     ---

--- a/restful_api/myapi/api/resources/progress.py
+++ b/restful_api/myapi/api/resources/progress.py
@@ -20,7 +20,57 @@ class ProgressResource(Resource):
                   properties:
                     msg:
                       type: string
-                      example: engineer progress retrieved
+                      example: engineer course progress retrieved
+                    progress:
+                      type: object
+                      example:
+                        no_sections: 4
+                        completed_sections: 3
+    """
+
+    method_decorators = [jwt_required()]
+
+    def get(self, eng_id, course_id, trainer_id):
+        num_sections = (ClassSection.query
+                        .filter_by(
+                            course_id=course_id,
+                            trainer_id=trainer_id
+                        )
+                        .count()
+                        )
+
+        num_completed_sections = (SectionCompleted.query
+                                  .filter_by(
+                                      course_id=course_id,
+                                      trainer_id=trainer_id,
+                                      eng_id=eng_id
+                                  )
+                                  .count()
+                                  )
+        
+        result = {
+          "no_sections": num_sections,
+          "completed_sections": num_completed_sections
+        }
+
+        return {"msg": "engineer course progress retrieved", "progress": result}, 
+      
+class ProgressListResource(Resource):
+    """Multiple object employee progress resource
+    ---
+    get:
+        tags:
+          - api
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    msg:
+                      type: string
+                      example: engineer overall course progress retrieved
                     progress:
                       type: object
                       example:
@@ -69,4 +119,4 @@ class ProgressResource(Resource):
                 "completed_sections": num_completed_sections,
             }
 
-        return {"msg": "engineer progress retrieved", "progress": json.dumps(result)}, 200
+        return {"msg": "engineer overall course progress retrieved", "progress": result}, 200

--- a/restful_api/myapi/api/views.py
+++ b/restful_api/myapi/api/views.py
@@ -14,6 +14,7 @@ from myapi.api.resources import (
     EnrollByEngineerSelfResourceList,
     EnrollByCourseResourceList,
     ProgressResource,
+    ProgressListResource,
     QuizResource,
     QuizResourceList,
 )
@@ -46,7 +47,8 @@ api.add_resource(CourseResource, "/course/<int:course_id>", endpoint="course")
 api.add_resource(CourseClassResource, "/course_class/<int:course_id>&<int:trainer_id>", endpoint="course_class")
 api.add_resource(ClassSectionResource, "/class_section/<int:section_id>", endpoint="class_section")
 api.add_resource(ClassSectionResourceList, "/class_sections/<int:course_id>&<int:trainer_id>&<int:eng_id>", endpoint="class_sections_by_course")
-api.add_resource(ProgressResource, "/progress/<int:eng_id>", endpoint="progress")
+api.add_resource(ProgressResource, "/course_progress/<int:course_id>&<int:trainer_id>&<int:eng_id>", endpoint="course_progress")
+api.add_resource(ProgressListResource, "/overall_progress/<int:eng_id>", endpoint="overall_progress")
 api.add_resource(QuizResource, "/quiz/<int:quiz_id>", endpoint="quiz")
 api.add_resource(QuizResourceList, "/quizzes/<int:section_id>", endpoint="quizzes")
 
@@ -74,6 +76,7 @@ def register_views():
     apispec.spec.path(view=CourseClassResource, app=current_app)
     apispec.spec.path(view=ClassSectionResource, app=current_app)
     apispec.spec.path(view=ProgressResource, app=current_app)
+    apispec.spec.path(view=ProgressListResource, app=current_app)
     apispec.spec.path(view=QuizResource, app=current_app)
     apispec.spec.path(view=QuizResourceList, app=current_app)
 

--- a/restful_api/tests/test_progress.py
+++ b/restful_api/tests/test_progress.py
@@ -2,7 +2,44 @@ from flask import url_for
 import json
 
 
-def test_get_employee_progress(
+def test_get_single_course_progress(
+    client,
+    db,
+    employee,
+    course_class,
+    class_section_factory,
+    section_completed_factory,
+    engineer_employee_headers,
+):
+
+    sections = [class_section_factory(course_class=course_class) for _ in range(4)]
+    db.session.add_all(sections + [employee])
+    db.session.commit()
+
+    progress_url = url_for(
+        'api.course_progress', 
+        eng_id=employee.id, 
+        course_id=course_class.course_id, 
+        trainer_id=course_class.trainer.id
+    )
+    
+    rep = client.get(progress_url, headers=engineer_employee_headers)
+    assert rep.status_code == 200
+    json_payload = rep.get_json()[0]['progress']
+    assert json_payload['completed_sections'] == 0
+    assert json_payload['no_sections'] == 4
+
+    completed_sections = [section_completed_factory(class_section=sections[i], engineer=employee) for i in range(3)]
+    db.session.add_all(completed_sections)
+    db.session.commit()
+    
+    rep = client.get(progress_url, headers=engineer_employee_headers)
+    assert rep.status_code == 200
+    json_payload = rep.get_json()[0]['progress']
+    assert json_payload['completed_sections'] == 3
+    assert json_payload['no_sections'] == 4
+
+def test_get_overall_progress(
     client,
     db,
     employee,
@@ -24,10 +61,10 @@ def test_get_employee_progress(
     db.session.add_all(completed_sections + sections + [employee, enrollment])
     db.session.commit()
 
-    progress_url = url_for('api.progress', eng_id=employee.id)
+    progress_url = url_for('api.overall_progress', eng_id=employee.id)
     rep = client.get(progress_url, headers=engineer_employee_headers)
     assert rep.status_code == 200
-    json_payload = json.loads(rep.get_json()['progress'])
+    json_payload = rep.get_json()['progress']
     assert json_payload[str(course_class.course_id)]['completed_sections'] == 3
     assert json_payload[str(course_class.course_id)]['no_sections'] == 4
 
@@ -35,15 +72,14 @@ def test_get_employee_progress(
     db.session.add(completed_section_4)
     db.session.commit()
 
-    progress_url = url_for('api.progress', eng_id=employee.id)
     rep = client.get(progress_url, headers=engineer_employee_headers)
     assert rep.status_code == 200
-    json_payload = json.loads(rep.get_json()['progress'])
+    json_payload = rep.get_json()['progress']
     assert json_payload[str(course_class.course_id)]['completed_sections'] == 4
     assert json_payload[str(course_class.course_id)]['no_sections'] == 4
 
 
-def test_get_employee_with_no_enrollment(
+def test_get_overall_progress_no_enrollment(
     client,
     db,
     employee,
@@ -58,6 +94,6 @@ def test_get_employee_with_no_enrollment(
     db.session.add_all(completed_sections + sections + [employee])
     db.session.commit()
 
-    progress_url = url_for('api.progress', eng_id=employee.id)
+    progress_url = url_for('api.overall_progress', eng_id=employee.id)
     rep = client.get(progress_url, headers=engineer_employee_headers)
     assert rep.status_code == 404

--- a/restful_api/tests/test_progress.py
+++ b/restful_api/tests/test_progress.py
@@ -1,5 +1,4 @@
 from flask import url_for
-import json
 
 
 def test_get_single_course_progress(
@@ -17,12 +16,12 @@ def test_get_single_course_progress(
     db.session.commit()
 
     progress_url = url_for(
-        'api.course_progress', 
-        eng_id=employee.id, 
-        course_id=course_class.course_id, 
+        'api.course_progress',
+        eng_id=employee.id,
+        course_id=course_class.course_id,
         trainer_id=course_class.trainer.id
     )
-    
+
     rep = client.get(progress_url, headers=engineer_employee_headers)
     assert rep.status_code == 200
     json_payload = rep.get_json()[0]['progress']
@@ -32,12 +31,13 @@ def test_get_single_course_progress(
     completed_sections = [section_completed_factory(class_section=sections[i], engineer=employee) for i in range(3)]
     db.session.add_all(completed_sections)
     db.session.commit()
-    
+
     rep = client.get(progress_url, headers=engineer_employee_headers)
     assert rep.status_code == 200
     json_payload = rep.get_json()[0]['progress']
     assert json_payload['completed_sections'] == 3
     assert json_payload['no_sections'] == 4
+
 
 def test_get_overall_progress(
     client,


### PR DESCRIPTION
# Summary

Endpoint to retrieve individual course progress for a given engineer. Takes in `course_id`, `trainer_id`, `eng_id` as arguments and checks number of section for given course and how many completed sections. 

# Changes
1. Refactor #42 to ProgressListResource, as this endpoint needs a single course, and the other is a list.
2. Remove `json.dumps` from ProgressListResource

# Notable
1. Flask RESTful doesn't need json dump for the return response. Returning a raw dict will suffice, it is handled under the hood.