### PR TITLE
SPM-62 Separate getting all courses and engineer statuses

### DIFF
--- a/restful_api/myapi/api/resources/__init__.py
+++ b/restful_api/myapi/api/resources/__init__.py
@@ -1,4 +1,4 @@
-from myapi.api.resources.course import CourseList, CourseResource
+from myapi.api.resources.course import CourseStatusList, CourseResource, CourseResourceList
 from myapi.api.resources.employee import EmployeeList, EmployeeResource
 from myapi.api.resources.enroll import EnrollResourceList, EnrollResource, EnrollByEngineerSelfResourceList, EnrollByCourseResourceList
 from myapi.api.resources.course_class import CourseClassResource
@@ -13,7 +13,8 @@ __all__ = [
     "EnrollResource",
     "EnrollByEngineerSelfResourceList",
     "EnrollByCourseResourceList",
-    "CourseList",
+    "CourseStatusList",
+    "CourseResourceList",
     "CourseResource",
     "CourseClassResource",
     "ClassSectionResource",

--- a/restful_api/myapi/api/resources/course.py
+++ b/restful_api/myapi/api/resources/course.py
@@ -103,7 +103,40 @@ class CourseResource(Resource):
         return {"msg": "course deleted"}, 204
 
 
-class CourseList(Resource):
+class CourseResourceList(Resource):
+    """Get all courses
+
+    ---
+    get:
+      tags:
+        - api
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  msg:
+                    type: string
+                    example: all courses retrieved
+                  result:
+                    type: array
+                    items: CourseSchema
+
+    """
+
+    method_decorators = [jwt_required()]
+
+    def get(self):
+
+        course_schema = CourseSchema(many=True)
+        all_courses = Course.query.all()
+
+        return {"msg": "all courses retrieved", "courses": course_schema.dump(all_courses)}, 200
+
+
+class CourseStatusList(Resource):
     """Get all courses, with boolean indicating if engineer is eligible / enrolled
 
     ---

--- a/restful_api/myapi/api/views.py
+++ b/restful_api/myapi/api/views.py
@@ -4,8 +4,9 @@ from marshmallow import ValidationError
 from myapi.api.resources import (
     EmployeeResource,
     EmployeeList,
-    CourseList,
+    CourseStatusList,
     CourseResource,
+    CourseResourceList,
     CourseClassResource,
     ClassSectionResource,
     ClassSectionResourceList,
@@ -42,7 +43,8 @@ api.add_resource(EnrollResource, "/enroll/<int:eng_id>&<int:course_id>&<int:trai
 api.add_resource(EnrollResourceList, "/enrollments/<int:eng_id>", endpoint="enrollments")
 api.add_resource(EnrollByEngineerSelfResourceList, "/self_enrollments_by_eng/<int:eng_id>", endpoint="self_enrollments_by_eng")
 api.add_resource(EnrollByCourseResourceList, "/enrollments_by_course/<int:course_id>", endpoint="enrollments_by_course")
-api.add_resource(CourseList, "/courses/<int:eng_id>", endpoint="courses")
+api.add_resource(CourseStatusList, "/courses/<int:eng_id>", endpoint="courses_status")
+api.add_resource(CourseResourceList, "/courses/all", endpoint="courses")
 api.add_resource(CourseResource, "/course/<int:course_id>", endpoint="course")
 api.add_resource(CourseClassResource, "/course_class/<int:course_id>&<int:trainer_id>", endpoint="course_class")
 api.add_resource(ClassSectionResource, "/class_section/<int:section_id>", endpoint="class_section")
@@ -72,7 +74,8 @@ def register_views():
     apispec.spec.path(view=EnrollResourceList, app=current_app)
     apispec.spec.path(view=EnrollByEngineerSelfResourceList, app=current_app)
     apispec.spec.path(view=EnrollByCourseResourceList, app=current_app)
-    apispec.spec.path(view=CourseList, app=current_app)
+    apispec.spec.path(view=CourseStatusList, app=current_app)
+    apispec.spec.path(view=CourseResourceList, app=current_app)
     apispec.spec.path(view=CourseResource, app=current_app)
     apispec.spec.path(view=CourseClassResource, app=current_app)
     apispec.spec.path(view=ClassSectionResource, app=current_app)


### PR DESCRIPTION
## Summary

In SPM-62, getting all courses was modified to get status of enrolled courses for each engineer. So the original get all courses endpoint was re-added.