### PR TITLE
SPM-50 Enroll course per engineer request

### DIFF
--- a/restful_api/myapi/api/resources/enroll.py
+++ b/restful_api/myapi/api/resources/enroll.py
@@ -15,6 +15,19 @@ class EnrollResource(Resource):
       get:
         tags:
           - api
+        parameters:
+        - name: eng_id
+          in: query
+          type: integer
+          required: true
+        - name: course_id
+          in: query
+          type: integer
+          required: true
+        - name: trainer_id
+          in: query
+          type: integer
+          required: true
         responses:
           200:
             content:

--- a/restful_api/myapi/api/resources/enroll.py
+++ b/restful_api/myapi/api/resources/enroll.py
@@ -136,6 +136,7 @@ class EnrollResource(Resource):
 
         enrollment_record.has_passed = updated_record.has_passed
         enrollment_record.is_official = updated_record.is_official
+        enrollment_record.is_approved = updated_record.is_approved
         db.session.commit()
 
         return {"msg": "enrollment updated", "enrollment": self.enroll_schema.dump(enrollment_record)}, 201
@@ -188,7 +189,7 @@ class EnrollResource(Resource):
 
 
 class EnrollResourceList(Resource):
-    """Get all enrolled learners based on engineer id
+    """Get all enrollement records based on engineer id
 
     ---
     get:

--- a/restful_api/myapi/api/schemas/enroll.py
+++ b/restful_api/myapi/api/schemas/enroll.py
@@ -11,6 +11,7 @@ class EnrollSchema(ma.SQLAlchemyAutoSchema):
     trainer_id = ma.Int()
     has_passed = ma.Boolean()
     is_official = ma.Boolean()
+    is_approved = ma.Boolean(default=None)
     created_timestamp = ma.Int()
 
     course = ma.Nested(CourseSchema, required=False)

--- a/restful_api/myapi/models/enroll.py
+++ b/restful_api/myapi/models/enroll.py
@@ -13,6 +13,7 @@ class Enroll(db.Model):
     trainer_id = db.Column(db.Integer, db.ForeignKey('employee.id'), primary_key=True)
     has_passed = db.Column(db.Boolean, default=False, nullable=False)
     is_official = db.Column(db.Boolean, default=False, nullable=False)
+    is_approved = db.Column(db.Boolean, default=None, nullable=True)
     created_timestamp = db.Column(db.Integer, default=int(time.time()))
 
     course = db.relationship('Course', backref=db.backref('enrollment_course', lazy='joined', cascade="all,delete"))

--- a/restful_api/tests/test_enroll.py
+++ b/restful_api/tests/test_enroll.py
@@ -32,6 +32,7 @@ def test_get_single_enrollment(
     assert rep.get_json()["enrollment"]["eng_id"] == enrollments[0].eng_id, "Incorrect engineer id retrieved by Enroll"
     assert rep.get_json()["enrollment"]["course_id"] == enrollments[0].course_id, "Incorrect course id retrieved by Enroll"
     assert rep.get_json()["enrollment"]["trainer_id"] == enrollments[0].trainer_id, "Incorrect trainer id retrieved by Enroll"
+    assert rep.get_json()["enrollment"]["is_approved"] == None, "Incorrect approval status retrieved by Enroll"
 
 
 def test_post_single_enrollment_official(
@@ -57,6 +58,7 @@ def test_post_single_enrollment_official(
     assert rep_json['enrollment']['trainer_id'] == enroll.trainer_id, "Incorrect trainer id retrieved"
     assert rep_json['enrollment']['has_passed'] == False, "Incorrect has passed retrieved"
     assert rep_json['enrollment']['is_official'] == True, "Incorrect official status retrieved"
+    assert rep_json['enrollment']['is_approved'] == None, "Incorrect approval status retrieved"
 
     # Create enrollment failure due to missing attributes
     request_json = {
@@ -116,7 +118,8 @@ def test_put_single_enrollment(
         'course_id': enrollments[0].eng_id,
         'trainer_id': enrollments[0].eng_id,
         'has_passed': False,
-        'is_official': True
+        'is_official': True,
+        'is_approved': True
     }
     rep = client.put(enrollment_url, json=request_json, headers=engineer_employee_headers)
     assert rep.status_code == 201, "Incorrect status code retrieved"
@@ -126,6 +129,7 @@ def test_put_single_enrollment(
     assert rep_json['enrollment']['trainer_id'] == enrollments[0].trainer_id, "Incorrect trainer id retrieved"
     assert rep_json['enrollment']['has_passed'] == False, "Incorrect has passed retrieved"
     assert rep_json['enrollment']['is_official'] == True, "Incorrect official status retrieved"
+    assert rep_json['enrollment']['is_approved'] == True, "Incorrect approval status retrieved"
 
 
 def test_delete_single_enrollment(

--- a/restful_api/tests/test_enroll.py
+++ b/restful_api/tests/test_enroll.py
@@ -32,7 +32,7 @@ def test_get_single_enrollment(
     assert rep.get_json()["enrollment"]["eng_id"] == enrollments[0].eng_id, "Incorrect engineer id retrieved by Enroll"
     assert rep.get_json()["enrollment"]["course_id"] == enrollments[0].course_id, "Incorrect course id retrieved by Enroll"
     assert rep.get_json()["enrollment"]["trainer_id"] == enrollments[0].trainer_id, "Incorrect trainer id retrieved by Enroll"
-    assert rep.get_json()["enrollment"]["is_approved"] == None, "Incorrect approval status retrieved by Enroll"
+    assert rep.get_json()["enrollment"]["is_approved"] is None, "Incorrect approval status retrieved by Enroll"
 
 
 def test_post_single_enrollment_official(
@@ -58,7 +58,7 @@ def test_post_single_enrollment_official(
     assert rep_json['enrollment']['trainer_id'] == enroll.trainer_id, "Incorrect trainer id retrieved"
     assert rep_json['enrollment']['has_passed'] == False, "Incorrect has passed retrieved"
     assert rep_json['enrollment']['is_official'] == True, "Incorrect official status retrieved"
-    assert rep_json['enrollment']['is_approved'] == None, "Incorrect approval status retrieved"
+    assert rep_json['enrollment']['is_approved'] is None, "Incorrect approval status retrieved"
 
     # Create enrollment failure due to missing attributes
     request_json = {


### PR DESCRIPTION
# Summary

This ticket is for HR to approve engineer's self enroll request.

# Changes
1. Added a field `is_approved` to Enroll model.
2. Added test cases for Enroll to verify field values
3. In `PUT` under EnrollResource, added a line to update `is_approved` as well.
